### PR TITLE
fix: deprecated warning

### DIFF
--- a/lib/commentable_methods.rb
+++ b/lib/commentable_methods.rb
@@ -57,9 +57,9 @@ module Juixe
             comment_roles.each do |role|
               define_role_based_inflection(role)
             end
-            has_many :all_comments, {:as => :commentable, :inverse_of => :commentable, :dependent => :destroy, class_name: 'Comment'}.merge(join_options)
+            has_many :all_comments, **{:as => :commentable, :inverse_of => :commentable, :dependent => :destroy, class_name: 'Comment'}.merge(join_options)
           else
-            has_many :comments, {:as => :commentable, :inverse_of => :commentable, :dependent => :destroy}.merge(join_options)
+            has_many :comments, **{:as => :commentable, :inverse_of => :commentable, :dependent => :destroy}.merge(join_options)
           end
 
           comment_types.each do |role|


### PR DESCRIPTION
warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call

---

@skillstream/ssnext-developers Tagging just incase you're not watching this repos.