### PR TITLE
fix: deprecated warning

### DIFF
--- a/lib/commentable_methods.rb
+++ b/lib/commentable_methods.rb
@@ -18,13 +18,13 @@ module Juixe
 
         def define_role_based_inflection_3(role)
           has_many "#{role.to_s}_comments".to_sym,
-                   has_many_options(role).merge(:conditions => { role: role.to_s })
+                   **has_many_options(role).merge(:conditions => { role: role.to_s })
         end
 
         def define_role_based_inflection_4(role)
           has_many "#{role.to_s}_comments".to_sym,
                    -> { where(role: role.to_s) },
-                   has_many_options(role)
+                   **has_many_options(role)
         end
         alias_method :define_role_based_inflection_5, :define_role_based_inflection_4
         alias_method :define_role_based_inflection_6, :define_role_based_inflection_4


### PR DESCRIPTION
warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call

@skillstream/ssnext-developers this is to address this deprecation warning when running the ssnext test suite:

```
...commentable_methods.rb:25: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
...activerecord-6.1.7/lib/active_record/associations.rb:1457: warning: The called method `has_many' is defined here
```